### PR TITLE
password should be invisible to the accessibility services

### DIFF
--- a/app/src/main/res/layout/content_add_account.xml
+++ b/app/src/main/res/layout/content_add_account.xml
@@ -92,7 +92,8 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:minHeight="60dp"
-                        android:inputType="textPassword" />
+                        android:inputType="textPassword"
+                        android:importantForAccessibility="no" />
                 </android.support.design.widget.TextInputLayout>
                 <android.support.v7.widget.AppCompatButton
                     android:layout_width="match_parent"
@@ -112,7 +113,8 @@
                         android:layout_height="wrap_content"
                         android:minHeight="60dp"
                         android:id="@+id/additional"
-                        android:inputType="textPassword" />
+                        android:inputType="textPassword"
+                        android:importantForAccessibility="no" />
                 </android.support.design.widget.TextInputLayout>
 
                 <android.support.design.widget.TextInputLayout


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service, can capture all user inputs. In this case, password, should be ignored for the accessibility service, so such attacks can not be happened.